### PR TITLE
Overwrite GPG keys

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ if [ -d "/home/codespace" ] && [ -f "/etc/debian_version" ]; then
         tealdeer
 
     wget -O- https://apt.releases.hashicorp.com/gpg | \
-        sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+        sudo gpg --yes --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
     echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
         sudo tee /etc/apt/sources.list.d/hashicorp.list
     sudo apt-get update
@@ -18,7 +18,7 @@ if [ -d "/home/codespace" ] && [ -f "/etc/debian_version" ]; then
     terraform -install-autocomplete
 
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-        sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+        sudo gpg --yes --dearmor -o /usr/share/keyrings/cloud.google.gpg
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
         sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
     sudo apt-get update


### PR DESCRIPTION
Overwrites GPG keys, when re-running the setup script. Avoids issue with script running being blocked, because of an interactive prompt.

Fixes #2.