### PR TITLE
Do not append Google Cloud SDK list

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -20,7 +20,7 @@ if [ -d "/home/codespace" ] && [ -f "/etc/debian_version" ]; then
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
         sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
-        sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+        sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list
     sudo apt-get update
     sudo apt-get install google-cloud-cli google-cloud-sdk-gke-gcloud-auth-plugin
 else


### PR DESCRIPTION
Don't append to the Google Cloud SDK list. Prevents multiple sources appearing.

Fixes #2.